### PR TITLE
add overall url

### DIFF
--- a/ffhb.py
+++ b/ffhb.py
@@ -11,6 +11,7 @@ import math
 NODELIST_URL = "http://downloads.bremen.freifunk.net/data/nodelist.json"
 NODES_URL = "http://downloads.bremen.freifunk.net/data/nodes.json"
 STATUS_URL = "http://status.ffhb.tk/data/merged.json"
+STATUS_OVERALL = "http://status.ffhb.tk/data/overall.json"
 STATUS_URL_RELOAD_MINUTES = 60
 CHANNEL = "#ffhb_gelaber"
 


### PR DESCRIPTION
Hier zum diskutieren:
TODO:
- zwischenspeichern und nur Untschiede anzeigen.
- Ab 51 Prozent als Fehler melden
- wenn Anfrage kommt und VPN(s) funktionieren, alles okay ausgeben.

@oliver in overall.json steht summary und topics - was ist das genau?
